### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: CI
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/RumenDamyanov/go-sudoku/security/code-scanning/1](https://github.com/RumenDamyanov/go-sudoku/security/code-scanning/1)

To fix the problem, add the `permissions` key to the workflow file `.github/workflows/ci.yml` to limit the access of the `GITHUB_TOKEN` to only what is required. Place it at the workflow root level (near the top) so it applies to all jobs unless overridden. For a Go CI workflow that checks out code and uploads coverage, the minimum required is generally `contents: read` (reading source code and fetching dependencies). Some actions like Codecov may need extra permissions if they interact with PRs or statuses, but the presented usage uses a token and doesn't appear to require specific repo write permissions. Therefore, add the following block near the top:

```yaml
permissions:
  contents: read
```

This should be inserted after the workflow name and before the triggers (`on:` block), say between lines 1 and 3. No imports or external dependencies are needed for YAML workflow files.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
