### PR TITLE
Potential fix for code scanning alert no. 2: Slice memory allocation with excessive size value

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -11,6 +11,7 @@ import (
 	"go.rumenx.com/sudoku"
 )
 
+
 var (
 	// override with -ldflags "-X main.version=... -X main.commit=... -X main.date=..."
 	version = "dev"
@@ -96,6 +97,11 @@ func handleGenerate(w http.ResponseWriter, r *http.Request) {
 	// variable size path
 	if req.Size <= 0 || req.Box == "" {
 		writeJSON(w, http.StatusBadRequest, errMsg("size and box required for variable grid"))
+		return
+	}
+	if req.Size > sudoku.MaxGridSize {
+		writeJSON(w, http.StatusBadRequest, errMsg(fmt.Sprintf(
+			"grid size %d exceeds maximum allowed (%d)", req.Size, sudoku.MaxGridSize)))
 		return
 	}
 	var br, bc int

--- a/grid.go
+++ b/grid.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 )
 
+// Maximum allowed grid size to prevent excessive memory usage.
+const MaxGridSize = 25
+
 // Grid is a generalised Sudoku grid of size SxS with sub-boxes boxRows x boxCols,
 // where S == boxRows*boxCols. Values are in [0..S], 0 meaning empty.
 type Grid struct {
@@ -18,6 +21,9 @@ type Grid struct {
 func NewGrid(size, boxRows, boxCols int) (Grid, error) {
 	if size <= 0 || boxRows <= 0 || boxCols <= 0 || size != boxRows*boxCols {
 		return Grid{}, fmt.Errorf("invalid dimensions: size=%d boxRows=%d boxCols=%d", size, boxRows, boxCols)
+	}
+	if size > MaxGridSize {
+		return Grid{}, fmt.Errorf("grid size %d exceeds maximum allowed (%d)", size, MaxGridSize)
 	}
 	g := Grid{Size: size, BoxRows: boxRows, BoxCols: boxCols, Cells: make([][]int, size)}
 	for i := range g.Cells {


### PR DESCRIPTION
Potential fix for [https://github.com/RumenDamyanov/go-sudoku/security/code-scanning/2](https://github.com/RumenDamyanov/go-sudoku/security/code-scanning/2)

The best way to solve this is to set an explicit upper bound for the allowed grid size/dimensions. All places where a grid is constructed from user input, notably in `cmd/server/main.go` in `handleGenerate`, should check that `req.Size` does not exceed a safe maximum (e.g., 25 for 25x25 Sudoku, which is much larger than typically needed). Add a check immediately after parsing/validating `req.Size` and the grid dimensions, and return a `BadRequest` error if the input is excessive. To ensure safety everywhere, also add a redundant check inside the `NewGrid` constructor in `grid.go`. This protects any future consumers of the API from this bug, even if they forget to check upstream. The value should be a constant (e.g., `const MaxGridSize = 25`) defined in `grid.go`, exported as needed, and referenced in both files.

This involves:  
- Adding a `MaxGridSize` constant in `grid.go`.  
- Updating `NewGrid` to check that `size <= MaxGridSize`.  
- Adding a check in `cmd/server/main.go` to ensure `req.Size` does not exceed `MaxGridSize` before calling `NewGrid`.  
- Optionally, update error messages to mention grid size limits.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
